### PR TITLE
Update tokens.mdx

### DIFF
--- a/apps/site/data/docs/core/tokens.mdx
+++ b/apps/site/data/docs/core/tokens.mdx
@@ -3,7 +3,7 @@ title: Tokens
 description: Accessing and using tokens
 ---
 
-Tamagui lets you create tokens using `createTokens`, which is then passed to the `createTamagui` function as part of the [configuration](/docs/intro/configuration) object.
+Tamagui lets you create tokens using `createTokens`, which is then passed to the `createTamagui` function as part of the [configuration](/docs/core/configuration) object.
 
 ### Getting tokens
 


### PR DESCRIPTION
 fixing Broken link: configuration object link on token page goes to 404 page #1507 